### PR TITLE
feat: contest time windows, virtual mode, and rated flag

### DIFF
--- a/docs/entity-relation-diagram.md
+++ b/docs/entity-relation-diagram.md
@@ -43,6 +43,9 @@ erDiagram
         timestamptz created_at
         timestamptz updated_at
         boolean is_active
+        timestamptz starts_at
+        timestamptz ends_at
+        boolean is_rated
         uuid created_by FK
     }
 
@@ -91,6 +94,7 @@ erDiagram
         uuid contest_id FK
         timestamptz joined_at
         timestamptz left_at
+        boolean is_virtual
     }
 
     countdown_timers {
@@ -109,7 +113,7 @@ erDiagram
 
     auth_users ||--o{ contests : "creates"
     auth_users ||--o{ problems : "creates"
-    
+
     auth_users ||--o{ contest_participants : "joins"
     contests ||--o{ contest_participants : "has"
 
@@ -120,7 +124,7 @@ erDiagram
     contests ||--o{ countdown_timers : "has"
 
     contests ||--o{ problems : "contains"
-    
+
     %% Note: submissions table foreign keys to users and problems weren't explicitly documented as DB constraints in the dump, but logically:
     users ||--o{ submissions : "makes"
     problems ||--o{ submissions : "receives"

--- a/docs/sequence-diagram.md
+++ b/docs/sequence-diagram.md
@@ -1,7 +1,7 @@
 ```mermaid
 sequenceDiagram
     autonumber
-    
+
     actor User
     actor Admin
     participant UI as Next.js Frontend
@@ -12,25 +12,40 @@ sequenceDiagram
     %% --- 1. Contest Participation Flow ---
     rect rgb(238, 238, 255)
     note right of User: Flow 1: Contest Participation
-    User->>UI: Clicks "Join Contest"
+    User->>UI: Clicks "Join Contest" / "Join (Virtual)" / "Rejoin"
     UI->>API: POST /api/contests/[id]/join
     API->>DB: Verify Auth Token (getUser)
     DB-->>API: Returns User Profile
-    
-    API->>DB: Check if Contest is active
-    DB-->>API: Returns Contest data (length, created_by)
-    
-    API->>DB: Check `join_history` & `contest_participants`
-    DB-->>API: Returns Participation Status
-    note right of API: Verifies user hasn't already<br/>joined/left another active contest.
-    
-    API->>DB: Insert into `join_history` & `contest_participants`
-    API->>DB: Upsert `countdown_timers` (Duration = Contest Length)
+
+    API->>DB: Fetch Contest (is_active, starts_at, ends_at, length, created_by)
+    DB-->>API: Returns Contest data
+    note right of API: Computes status from starts_at / ends_at:<br/>upcoming / ongoing / virtual / inactive
+
+    alt status = inactive
+        API-->>UI: 403 Contest is not active
+    else status = upcoming
+        API-->>UI: 403 Contest has not started yet
+    else status = ongoing
+        API->>DB: Check join_history for this user+contest
+        DB-->>API: Returns history rows
+        note right of API: If any history row exists → block rejoin (403).<br/>Ongoing contests allow only one participation.
+    else status = virtual
+        API->>DB: Check join_history for this user+contest
+        DB-->>API: Returns history rows
+        note right of API: History rows are ignored for virtual contests.<br/>Re-joining is freely allowed.
+    end
+
+    API->>DB: Check contest_participants (already active in another contest?)
+    DB-->>API: Returns active participation
+
+    API->>DB: Insert into join_history (is_virtual = status === "virtual")
+    API->>DB: Insert into contest_participants
+    API->>DB: Upsert countdown_timers (Duration = Contest Length)
     DB-->>API: Acknowledgement
     API-->>UI: 200 OK (Contest Joined)
     UI-->>User: Redirects to Contest Dashboard<br/>Starts Countdown Timer
     end
-    
+
     %% --- 2. User Code Submission Flow ---
     rect rgb(240, 255, 240)
     note right of User: Flow 2: Code Submission
@@ -38,20 +53,20 @@ sequenceDiagram
     UI->>API: POST /api/problems/[id]/submit {code, language}
     API->>DB: Verify Auth Token
     DB-->>API: Returns User ID
-    
+
     API->>DB: Fetch Problem Details (time/memory limits, input/output)
     DB-->>API: Returns Problem Details
-    
+
     alt If Problem belongs to a Contest
-        API->>DB: Check `contest_participants` & `countdown_timers`
+        API->>DB: Check contest_participants & countdown_timers
         DB-->>API: Validates Timer has not expired
     end
-    
+
     API->>Judge: POST /submit {code, input, output, limits}
     note right of Judge: Compiles code in Sandbox.<br/>Runs tests synchronously.
     Judge-->>API: Returns Execution Results (Passed/Failed test cases, Time/Memory used)
-    
-    API->>DB: Insert into `submissions` table (results, code, status)
+
+    API->>DB: Insert into submissions table (results, code, status)
     DB-->>API: Ack
     API-->>UI: Returns Evaluation Summary
     UI-->>User: Displays "Accepted" or "Failed" Visuals
@@ -62,21 +77,21 @@ sequenceDiagram
     note right of Admin: Flow 3: Admin Test Case Generation
     Admin->>UI: Writes C++ Generator Code, clicks "Generate"
     UI->>API: POST /api/admin/problems/generator/generate {code}
-    
+
     API->>DB: Verify Auth Token
     DB-->>API: Returns User ID
-    
-    API->>DB: Lookup `admins` table by ID
+
+    API->>DB: Lookup admins table by ID
     DB-->>API: Returns is_active: true
     note right of API: Validates caller has Admin Role
-    
+
     API->>Judge: POST /generate-tests {language: "cpp", code}
     note right of Judge: Compiles C++ test generator.<br/>Executes to produce random test suites.
-    Judge-->>API: Returns generated `input` & `output` JSON arrays
-    
+    Judge-->>API: Returns generated input & output JSON arrays
+
     API-->>UI: Returns Generated JSON Data
     UI-->>Admin: Previews generated inputs/outputs in UI Editor
-    
+
     %% Implicit step: saving the problem
     opt Admin saves the problem
         Admin->>UI: Clicks "Save Problem"

--- a/main/src/app/admin/contests/create/CreateContestClient.tsx
+++ b/main/src/app/admin/contests/create/CreateContestClient.tsx
@@ -11,7 +11,6 @@ import DataTable, { type DataTableColumn } from '@/components/DataTable';
 import { LoadingSpinner } from '@/components/AnimationWrapper';
 
 const MarkdownEditor = dynamic(() => import('@/components/MarkdownEditor').then(m => m.MarkdownEditor), { ssr: false });
-const MarkdownRenderer = dynamic(() => import('@/components/MarkdownRenderer').then(m => m.MarkdownRenderer), { ssr: false });
 
 const inputClass = "w-full h-10 px-3 bg-surface-2 border border-border rounded-md text-sm text-foreground placeholder-text-muted/50 focus:outline-none focus:border-brand-primary focus:ring-2 focus:ring-brand-primary/20";
 
@@ -21,25 +20,46 @@ export default function CreateContestClient() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
-  const [formData, setFormData] = useState({ name: '', description: '', length: 60 });
+  const [formData, setFormData] = useState({
+    name: '', description: '', length: 60,
+    starts_at: '', ends_at: '', is_rated: false
+  });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: name === 'length' ? parseInt(value) || 0 : value }));
   };
 
+  const handleCheckbox = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({ ...prev, [e.target.name]: e.target.checked }));
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault(); setLoading(true); setError(''); setSuccess('');
+
+    if (formData.starts_at && formData.ends_at && new Date(formData.starts_at) >= new Date(formData.ends_at)) {
+      setError('Start date/time must be before end date/time');
+      setLoading(false);
+      return;
+    }
+
     try {
       const res = await fetch('/api/admin/contests/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}) },
-        body: JSON.stringify(formData)
+        body: JSON.stringify({
+          name: formData.name,
+          description: formData.description,
+          length: formData.length,
+          starts_at: formData.starts_at ? new Date(formData.starts_at).toISOString() : null,
+          ends_at: formData.ends_at ? new Date(formData.ends_at).toISOString() : null,
+          is_rated: formData.is_rated,
+        })
       });
       const json = await res.json();
       if (res.ok) {
         setSuccess('Contest created successfully!');
-        setFormData({ name: '', description: '', length: 60 });
+        setFormData({ name: '', description: '', length: 60, starts_at: '', ends_at: '', is_rated: false });
         setTimeout(() => router.push('/admin/dashboard'), 2000);
       } else { setError(json.error || 'Failed to create contest'); }
     } catch { setError('An unexpected error occurred'); }
@@ -70,6 +90,49 @@ export default function CreateContestClient() {
               <label htmlFor="length" className="block text-sm font-medium text-foreground">Duration (minutes) *</label>
               <input type="number" id="length" name="length" value={formData.length} onChange={handleChange} required min="1" max="1440" className={inputClass} placeholder="60" />
               <p className="text-xs text-text-muted">Contest duration in minutes (1–1440)</p>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-4 max-w-lg">
+              <div className="space-y-1.5">
+                <label htmlFor="starts_at" className="block text-sm font-medium text-foreground">
+                  Start Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                </label>
+                <input
+                  type="datetime-local"
+                  id="starts_at"
+                  name="starts_at"
+                  value={formData.starts_at}
+                  onChange={handleChange}
+                  className={inputClass}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label htmlFor="ends_at" className="block text-sm font-medium text-foreground">
+                  End Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                </label>
+                <input
+                  type="datetime-local"
+                  id="ends_at"
+                  name="ends_at"
+                  value={formData.ends_at}
+                  onChange={handleChange}
+                  className={inputClass}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="inline-flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="is_rated"
+                  className="h-4 w-4 rounded border-border bg-surface-2"
+                  checked={formData.is_rated}
+                  onChange={handleCheckbox}
+                />
+                Rated Contest
+              </label>
+              <p className="text-xs text-text-muted">Rated contests will affect player rankings (not yet implemented).</p>
             </div>
 
             {/* Summary Preview */}

--- a/main/src/app/admin/contests/manage/ManageContestsClient.tsx
+++ b/main/src/app/admin/contests/manage/ManageContestsClient.tsx
@@ -8,19 +8,33 @@ import { useAuth } from '@/contexts/AuthContext';
 import DataTable, { type DataTableColumn } from '@/components/DataTable';
 import { Badge } from '@/components/ui/Badge';
 import { SkeletonText } from '@/components/LoadingStates';
+import { getContestStatus, toLocalDatetimeInput, fromLocalDatetimeInput } from '@/utils/contestStatus';
+import type { ContestStatus } from '@/types/contest';
 
 interface ContestRow {
   id: string; name: string; length: number | null;
   is_active: boolean | null; created_at: string; updated_at: string;
+  starts_at: string | null; ends_at: string | null; is_rated: boolean;
 }
 
 interface EditState {
   id: string; name: string; description: string; length: number | null;
+  starts_at: string; ends_at: string; is_rated: boolean;
 }
 
 const MarkdownEditor = dynamic(() => import('@/components/MarkdownEditor').then(m => m.MarkdownEditor), { ssr: false });
 
 const inputClass = "w-full h-9 px-3 bg-surface-2 border border-border rounded-md text-sm text-foreground focus:outline-none focus:border-brand-primary focus:ring-2 focus:ring-brand-primary/20";
+
+const STATUS_VARIANT: Record<ContestStatus, 'success' | 'info' | 'warning' | 'neutral'> = {
+  ongoing: 'success', upcoming: 'info', virtual: 'warning', inactive: 'neutral',
+};
+const STATUS_LABEL: Record<ContestStatus, string> = {
+  ongoing: 'Ongoing', upcoming: 'Upcoming', virtual: 'Virtual', inactive: 'Inactive',
+};
+const STATUS_SORT_ORDER: Record<ContestStatus, number> = {
+  ongoing: 3, upcoming: 2, virtual: 1, inactive: 0,
+};
 
 export default function ManageContestsClient({ initialContests }: { initialContests: ContestRow[] }) {
   const { session } = useAuth();
@@ -48,7 +62,15 @@ export default function ManageContestsClient({ initialContests }: { initialConte
       const res = await fetch(`/api/admin/contests/${c.id}`, { headers: token ? { Authorization: `Bearer ${token}` } : undefined });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to load contest');
-      setEditing({ id: c.id, name: data.contest.name, description: data.contest.description || '', length: data.contest.length || null });
+      setEditing({
+        id: c.id,
+        name: data.contest.name,
+        description: data.contest.description || '',
+        length: data.contest.length || null,
+        starts_at: data.contest.starts_at ? toLocalDatetimeInput(data.contest.starts_at) : '',
+        ends_at: data.contest.ends_at ? toLocalDatetimeInput(data.contest.ends_at) : '',
+        is_rated: !!data.contest.is_rated,
+      });
     } catch (e: unknown) { setActionMessage(e instanceof Error ? e.message : 'Failed to open editor'); }
     finally { setFetchingEditContent(false); }
   };
@@ -57,16 +79,35 @@ export default function ManageContestsClient({ initialContests }: { initialConte
 
   const saveEdit = async () => {
     if (!editing) return;
+    if (editing.starts_at && editing.ends_at && new Date(editing.starts_at) >= new Date(editing.ends_at)) {
+      setActionMessage('Start date/time must be before end date/time');
+      return;
+    }
     try {
       const res = await fetch(`/api/admin/contests/${editing.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
-        body: JSON.stringify({ name: editing.name, description: editing.description, length: editing.length }),
+        body: JSON.stringify({
+          name: editing.name,
+          description: editing.description,
+          length: editing.length,
+          starts_at: editing.starts_at ? fromLocalDatetimeInput(editing.starts_at) : null,
+          ends_at: editing.ends_at ? fromLocalDatetimeInput(editing.ends_at) : null,
+          is_rated: editing.is_rated,
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to save');
       setActionMessage('Contest updated');
-      setContests(prev => prev.map(c => c.id === editing.id ? { ...c, name: editing.name, length: editing.length ?? c.length, updated_at: new Date().toISOString() } : c));
+      setContests(prev => prev.map(c => c.id === editing.id ? {
+        ...c,
+        name: editing.name,
+        length: editing.length ?? c.length,
+        starts_at: editing.starts_at ? fromLocalDatetimeInput(editing.starts_at) : null,
+        ends_at: editing.ends_at ? fromLocalDatetimeInput(editing.ends_at) : null,
+        is_rated: editing.is_rated,
+        updated_at: new Date().toISOString(),
+      } : c));
       closeEdit();
     } catch (e: unknown) { setActionMessage(e instanceof Error ? e.message : 'Failed to save'); }
   };
@@ -86,11 +127,18 @@ export default function ManageContestsClient({ initialContests }: { initialConte
   type Row = ContestRow;
   const columns: Array<DataTableColumn<Row>> = [
     { key: 'name', header: 'Name', className: 'w-[25%]', sortable: true, sortAccessor: (r) => r.name.toLowerCase(), render: (r) => <span className="text-foreground font-medium">{r.name}</span> },
-    { key: 'length', header: 'Length', className: 'w-[15%]', sortable: true, sortAccessor: (r) => r.length ?? 0, render: (r) => <span className="text-text-muted font-mono">{r.length ? `${r.length} min` : '-'}</span> },
-    { key: 'status', header: 'Status', className: 'w-[12%]', sortable: true, sortAccessor: (r) => (r.is_active ? 1 : 0), render: (r) => <Badge variant={r.is_active ? 'success' : 'warning'}>{r.is_active ? 'Active' : 'Inactive'}</Badge> },
+    { key: 'length', header: 'Length', className: 'w-[12%]', sortable: true, sortAccessor: (r) => r.length ?? 0, render: (r) => <span className="text-text-muted font-mono">{r.length ? `${r.length} min` : '-'}</span> },
+    {
+      key: 'status', header: 'Status', className: 'w-[14%]', sortable: true,
+      sortAccessor: (r) => STATUS_SORT_ORDER[getContestStatus({ is_active: !!r.is_active, starts_at: r.starts_at, ends_at: r.ends_at })],
+      render: (r) => {
+        const s = getContestStatus({ is_active: !!r.is_active, starts_at: r.starts_at, ends_at: r.ends_at });
+        return <Badge variant={STATUS_VARIANT[s]}>{STATUS_LABEL[s]}</Badge>;
+      }
+    },
     { key: 'updated', header: 'Updated', className: 'w-[15%]', sortable: true, sortAccessor: (r) => new Date(r.updated_at).getTime(), render: (r) => <span className="text-text-muted text-sm font-mono">{new Date(r.updated_at).toLocaleDateString()}</span> },
     {
-      key: 'actions', header: 'Actions', className: 'w-[33%]', render: (r) => (
+      key: 'actions', header: 'Actions', className: 'w-[34%]', render: (r) => (
         <div className="flex gap-1.5">
           <button onClick={() => openEdit(r)} className="px-2.5 py-1.5 rounded-md text-xs font-medium bg-brand-primary/10 text-brand-primary hover:bg-brand-primary/20">Edit</button>
           <button onClick={() => deleteContest(r)} className="px-2.5 py-1.5 rounded-md text-xs font-medium bg-error/10 text-error hover:bg-error/20">Delete</button>
@@ -156,6 +204,42 @@ export default function ManageContestsClient({ initialContests }: { initialConte
                         <label className="block text-sm font-medium text-foreground">Length (minutes)</label>
                         <input type="number" className={`${inputClass} max-w-xs`} value={editing.length ?? ''} onChange={e => setEditing(s => s ? { ...s, length: e.target.value ? Number(e.target.value) : null } : s)} />
                         <p className="text-xs text-text-muted">Leave blank for unspecified length.</p>
+                      </div>
+                      <div className="grid md:grid-cols-2 gap-4">
+                        <div className="space-y-1.5">
+                          <label className="block text-sm font-medium text-foreground">
+                            Start Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                          </label>
+                          <input
+                            type="datetime-local"
+                            className={inputClass}
+                            value={editing.starts_at}
+                            onChange={e => setEditing(s => s ? { ...s, starts_at: e.target.value } : s)}
+                          />
+                        </div>
+                        <div className="space-y-1.5">
+                          <label className="block text-sm font-medium text-foreground">
+                            End Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                          </label>
+                          <input
+                            type="datetime-local"
+                            className={inputClass}
+                            value={editing.ends_at}
+                            onChange={e => setEditing(s => s ? { ...s, ends_at: e.target.value } : s)}
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <label className="inline-flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-border bg-surface-2"
+                            checked={editing.is_rated}
+                            onChange={e => setEditing(s => s ? { ...s, is_rated: e.target.checked } : s)}
+                          />
+                          Rated Contest
+                        </label>
+                        <p className="text-xs text-text-muted mt-1">Rated contests will affect player rankings (not yet implemented).</p>
                       </div>
                       <div className="space-y-1.5">
                         <label className="block text-sm font-medium text-foreground">Description (Markdown)</label>

--- a/main/src/app/admin/contests/manage/page.tsx
+++ b/main/src/app/admin/contests/manage/page.tsx
@@ -18,7 +18,7 @@ export default async function ManageContestsPage() {
   if (!adminRow) redirect('/dashboard');
   const { data } = await supabase
     .from('contests')
-    .select('id,name,length,is_active,updated_at,created_at')
+    .select('id,name,length,is_active,updated_at,created_at,starts_at,ends_at,is_rated')
     .eq('created_by', userId);
 
   return <ManageContestsClient initialContests={data || []} />;

--- a/main/src/app/api/admin/contests/[id]/route.ts
+++ b/main/src/app/api/admin/contests/[id]/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const { supabase } = auth;
   const { data, error } = await supabase
     .from('contests')
-    .select('id,name,description,length,is_active,created_at,updated_at')
+    .select('id,name,description,length,is_active,created_at,updated_at,starts_at,ends_at,is_rated')
     .eq('id', id)
     .maybeSingle();
   if (error) {
@@ -47,6 +47,9 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   if (body.name !== undefined) updates.name = body.name;
   if (body.description !== undefined) updates.description = body.description;
   if (body.length !== undefined) updates.length = body.length;
+  if (body.starts_at !== undefined) updates.starts_at = body.starts_at || null;
+  if (body.ends_at !== undefined) updates.ends_at = body.ends_at || null;
+  if (body.is_rated !== undefined) updates.is_rated = !!body.is_rated;
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 });
   }

--- a/main/src/app/api/admin/contests/create/route.ts
+++ b/main/src/app/api/admin/contests/create/route.ts
@@ -3,7 +3,7 @@ import { getServerSupabase, getServerSupabaseFromToken } from '@/lib/supabaseSer
 
 export async function POST(request: NextRequest) {
   try {
-    const { name, description, length } = await request.json();
+    const { name, description, length, starts_at, ends_at, is_rated } = await request.json();
 
     if (!name || !description || !length) {
       return NextResponse.json(
@@ -15,6 +15,13 @@ export async function POST(request: NextRequest) {
     if (length < 1 || length > 1440) {
       return NextResponse.json(
         { error: 'Length must be between 1 and 1440 minutes' },
+        { status: 400 }
+      );
+    }
+
+    if (starts_at && ends_at && new Date(starts_at) >= new Date(ends_at)) {
+      return NextResponse.json(
+        { error: 'Start date/time must be before end date/time' },
         { status: 400 }
       );
     }
@@ -59,7 +66,10 @@ export async function POST(request: NextRequest) {
           description,
           length,
           is_active: false,
-          created_by: authUser.id
+          created_by: authUser.id,
+          starts_at: starts_at || null,
+          ends_at: ends_at || null,
+          is_rated: is_rated ?? false
         }
       ])
       .select()

--- a/main/src/app/api/contests/[id]/join/route.ts
+++ b/main/src/app/api/contests/[id]/join/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getServerSupabaseFromToken } from '@/lib/supabaseServer';
+import { getContestStatus } from '@/utils/contestStatus';
 
 export async function POST(
   request: Request,
@@ -34,7 +35,7 @@ export async function POST(
     // Ensure contest is active and get contest details
     const { data: contest, error: contestErr } = await supabase
       .from('contests')
-      .select('id,is_active,length,created_by')
+      .select('id, is_active, length, created_by, starts_at, ends_at, is_rated')
       .eq('id', id)
       .maybeSingle();
 
@@ -45,6 +46,13 @@ export async function POST(
     if (!contest || !contest.is_active) {
       console.log('Contest not found or inactive:', { contest, is_active: contest?.is_active });
       return NextResponse.json({ error: 'Contest is not active' }, { status: 403 });
+    }
+
+    // Compute contest status to enforce join rules
+    const status = getContestStatus(contest);
+
+    if (status === 'upcoming') {
+      return NextResponse.json({ error: 'Contest has not started yet' }, { status: 403 });
     }
 
     // Check if admin is trying to join their own contest
@@ -85,7 +93,8 @@ export async function POST(
       return NextResponse.json({ error: 'Failed to check join history' }, { status: 500 });
     }
 
-    if (historyData && historyData.length > 0) {
+    // Block rejoin for ongoing contests, but allow for virtual (free re-join)
+    if (historyData && historyData.length > 0 && status !== 'virtual') {
       return NextResponse.json({ error: 'You have already left this contest and cannot rejoin' }, { status: 403 });
     }
 
@@ -102,13 +111,16 @@ export async function POST(
       return NextResponse.json({ error: 'User already joined another contest' }, { status: 409 });
     }
 
+    const isVirtual = status === 'virtual';
+
     // Record join in history
     const { error: joinHistoryErr } = await supabase
       .from('join_history')
       .insert({
         user_id: userId,
         contest_id: id,
-        joined_at: new Date().toISOString()
+        joined_at: new Date().toISOString(),
+        is_virtual: isVirtual
       });
 
     if (joinHistoryErr) {
@@ -149,5 +161,3 @@ export async function POST(
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
-
-

--- a/main/src/app/api/contests/[id]/leaderboard/route.ts
+++ b/main/src/app/api/contests/[id]/leaderboard/route.ts
@@ -29,17 +29,27 @@ export async function GET(
       return NextResponse.json({ leaderboard: [] });
     }
 
-    // Get all submissions for this contest
-    const { data: submissions, error: submissionsErr } = await supabase
-      .from('submissions')
-      .select(`
-        user_id,
-        problem_id,
-        results,
-        summary,
-        created_at
-      `)
-      .in('problem_id', problemIds);
+    // Fetch submissions and non-virtual participants in parallel
+    const [submissionsResult, regularParticipantsResult] = await Promise.all([
+      supabase
+        .from('submissions')
+        .select(`
+          user_id,
+          problem_id,
+          results,
+          summary,
+          created_at
+        `)
+        .in('problem_id', problemIds),
+      supabase
+        .from('join_history')
+        .select('user_id')
+        .eq('contest_id', id)
+        .eq('is_virtual', false)
+    ]);
+
+    const { data: submissions, error: submissionsErr } = submissionsResult;
+    const { data: regularParticipants } = regularParticipantsResult;
 
     if (submissionsErr) {
       console.log('Submissions fetch error:', submissionsErr);
@@ -47,6 +57,11 @@ export async function GET(
     }
 
     console.log('Submissions query result:', { submissions, submissionsErr, problemIds });
+
+    // Build a set of user IDs who joined regularly (non-virtual).
+    // If size > 0, filter to only those users. If size = 0 (old contest with no
+    // join_history rows), include everyone for backward compatibility.
+    const regularUserIds = new Set((regularParticipants || []).map(r => r.user_id));
 
     const totalProblems = problemIds.length;
 
@@ -61,6 +76,9 @@ export async function GET(
     submissions?.forEach(submission => {
       // Use Set for O(1) lookup instead of Array.includes O(n)
       if (!problemIdSet.has(submission.problem_id)) return;
+
+      // Exclude virtual participants from the leaderboard
+      if (regularUserIds.size > 0 && !regularUserIds.has(submission.user_id)) return;
 
       const userId = submission.user_id;
       if (!userScores.has(userId)) {
@@ -118,7 +136,7 @@ export async function GET(
         userData.problemScores.forEach(score => {
           if (score >= 0.999) solvedCount++; // Floating point tolerance
         });
-        
+
         return {
           user_id: userData.userId,
           username: user?.username || user?.email?.split('@')[0] || 'Unknown',

--- a/main/src/app/api/contests/join-history/route.ts
+++ b/main/src/app/api/contests/join-history/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
 
     const { data, error } = await supabase
       .from('join_history')
-      .select('contest_id')
+      .select('contest_id, is_virtual')
       .eq('user_id', userId);
 
     if (error) {
@@ -26,11 +26,28 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Failed to fetch join history' }, { status: 500 });
     }
 
-    const contest_ids = (data || [])
+    const rows = data || [];
+
+    const contest_ids = rows
       .map(row => row.contest_id)
       .filter((id: string | null): id is string => !!id);
 
-    return NextResponse.json({ contest_ids });
+    // Compute which contests have ONLY virtual joins (all rows for that contest are is_virtual=true)
+    // Used by the UI to show "Rejoin" instead of "Spectate"
+    const contestJoinMap = new Map<string, boolean[]>();
+    for (const row of rows) {
+      if (!row.contest_id) continue;
+      if (!contestJoinMap.has(row.contest_id)) {
+        contestJoinMap.set(row.contest_id, []);
+      }
+      contestJoinMap.get(row.contest_id)!.push(row.is_virtual);
+    }
+
+    const virtual_contest_ids = Array.from(contestJoinMap.entries())
+      .filter(([, flags]) => flags.every(f => f === true))
+      .map(([id]) => id);
+
+    return NextResponse.json({ contest_ids, virtual_contest_ids });
   } catch (e) {
     console.error('join-history error:', e);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/main/src/app/api/manager/contests/[id]/route.ts
+++ b/main/src/app/api/manager/contests/[id]/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const { supabase } = auth;
   const { data, error } = await supabase
     .from('contests')
-    .select('id,name,description,length,is_active,created_at,updated_at')
+    .select('id, name, description, length, is_active, created_at, updated_at, starts_at, ends_at, is_rated')
     .eq('id', id)
     .maybeSingle();
   if (error) {
@@ -30,6 +30,9 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   if (body.description !== undefined) updates.description = body.description;
   if (body.length !== undefined) updates.length = body.length;
   if (body.is_active !== undefined) updates.is_active = !!body.is_active;
+  if (body.starts_at !== undefined) updates.starts_at = body.starts_at || null;
+  if (body.ends_at !== undefined) updates.ends_at = body.ends_at || null;
+  if (body.is_rated !== undefined) updates.is_rated = !!body.is_rated;
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 });
   }

--- a/main/src/app/api/manager/contests/create/route.ts
+++ b/main/src/app/api/manager/contests/create/route.ts
@@ -3,7 +3,7 @@ import { getManagerSupabase } from '@/lib/managerAuth';
 
 export async function POST(request: NextRequest) {
   try {
-    const { name, description, length } = await request.json();
+    const { name, description, length, starts_at, ends_at, is_rated } = await request.json();
 
     if (!name || !description || !length) {
       return NextResponse.json(
@@ -15,6 +15,13 @@ export async function POST(request: NextRequest) {
     if (length < 1 || length > 1440) {
       return NextResponse.json(
         { error: 'Length must be between 1 and 1440 minutes' },
+        { status: 400 }
+      );
+    }
+
+    if (starts_at && ends_at && new Date(starts_at) >= new Date(ends_at)) {
+      return NextResponse.json(
+        { error: 'Start date/time must be before end date/time' },
         { status: 400 }
       );
     }
@@ -31,7 +38,10 @@ export async function POST(request: NextRequest) {
           description,
           length,
           is_active: true,
-          created_by: user.id
+          created_by: user.id,
+          starts_at: starts_at || null,
+          ends_at: ends_at || null,
+          is_rated: is_rated ?? false
         }
       ])
       .select()

--- a/main/src/app/contests/ContestsClient.tsx
+++ b/main/src/app/contests/ContestsClient.tsx
@@ -7,23 +7,43 @@ import { useAuth } from '@/contexts/AuthContext';
 import { AuthGuard } from '@/components/AuthGuard';
 import { RegularOnlyGuard } from '@/components/RegularOnlyGuard';
 import DataTable, { type DataTableColumn } from '@/components/DataTable';
-import { Contest } from '@/types/contest';
+import { Contest, ContestStatus } from '@/types/contest';
 import { Badge } from '@/components/ui/Badge';
+import { getContestStatus, formatTimeUntil } from '@/utils/contestStatus';
 
 interface ContestsClientProps {
   initialContests: Contest[];
   fetchError?: string;
 }
 
+const STATUS_VARIANT: Record<ContestStatus, 'success' | 'info' | 'warning' | 'neutral'> = {
+  ongoing:  'success',
+  upcoming: 'info',
+  virtual:  'warning',
+  inactive: 'neutral',
+};
+
+const STATUS_LABEL: Record<ContestStatus, string> = {
+  ongoing:  'Ongoing',
+  upcoming: 'Upcoming',
+  virtual:  'Virtual',
+  inactive: 'Inactive',
+};
+
+const STATUS_SORT_ORDER: Record<ContestStatus, number> = {
+  ongoing: 3, upcoming: 2, virtual: 1, inactive: 0,
+};
+
 export default function ContestsClient({ initialContests, fetchError }: ContestsClientProps) {
   const { session } = useAuth();
   const [contests] = useState<Contest[]>(initialContests);
   const [joinedContestId, setJoinedContestId] = useState<string | null>(null);
   const [joinedHistory, setJoinedHistory] = useState<Set<string>>(new Set());
+  const [virtualContestIds, setVirtualContestIds] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState('');
 
   const fetcher = (url: string) => fetch(url, { headers: { 'Authorization': `Bearer ${session?.access_token}` } }).then(r => r.json());
-  
+
   const { data: participation } = useSWR(session?.access_token ? '/api/contests/participation' : null, fetcher);
   const { data: joinHistory } = useSWR(session?.access_token ? '/api/contests/join-history' : null, fetcher);
 
@@ -34,6 +54,9 @@ export default function ContestsClient({ initialContests, fetchError }: Contests
   useEffect(() => {
     if (joinHistory?.contest_ids && Array.isArray(joinHistory.contest_ids)) {
       setJoinedHistory(new Set(joinHistory.contest_ids));
+    }
+    if (joinHistory?.virtual_contest_ids && Array.isArray(joinHistory.virtual_contest_ids)) {
+      setVirtualContestIds(new Set(joinHistory.virtual_contest_ids));
     }
   }, [joinHistory]);
 
@@ -52,13 +75,54 @@ export default function ContestsClient({ initialContests, fetchError }: Contests
         </div>
       )
     },
-    { key: 'length', header: 'Duration', className: 'w-[15%]', sortable: true, sortAccessor: (r) => r.length, render: (r) => <span className="text-sm text-foreground">{r.length} min</span> },
-    { key: 'status', header: 'Status', className: 'w-[15%]', sortable: true, sortAccessor: (r) => (r.is_active ? 1 : 0), render: (r) => <Badge variant={r.is_active ? 'success' : 'neutral'}>{r.is_active ? 'Active' : 'Inactive'}</Badge> },
-    { key: 'participants', header: 'Participants', className: 'w-[15%]', sortable: true, sortAccessor: (r) => r.participants_count ?? 0, render: (r) => <span className="text-sm text-text-muted">{r.participants_count ?? 0}</span> },
+    { key: 'length', header: 'Duration', className: 'w-[13%]', sortable: true, sortAccessor: (r) => r.length, render: (r) => <span className="text-sm text-foreground">{r.length} min</span> },
     {
-      key: 'actions', header: '', className: 'w-[20%] text-right', render: (r) => {
-        if (joinedContestId === r.id) return <Link href={`/contests/${r.id}`} className="text-sm font-medium text-brand-primary hover:text-brand-secondary">Continue →</Link>;
-        if (joinedHistory.has(r.id)) return <Link href={`/contests/${r.id}/leaderboard`} className="text-sm font-medium text-text-muted hover:text-foreground">Spectate</Link>;
+      key: 'status', header: 'Status', className: 'w-[15%]', sortable: true,
+      sortAccessor: (r) => STATUS_SORT_ORDER[getContestStatus(r)],
+      render: (r) => {
+        const s = getContestStatus(r);
+        const timeHint =
+          s === 'upcoming' && r.starts_at ? formatTimeUntil(r.starts_at) :
+          s === 'ongoing'  && r.ends_at   ? formatTimeUntil(r.ends_at)   :
+          null;
+        return (
+          <div className="flex flex-col gap-0.5">
+            <Badge variant={STATUS_VARIANT[s]}>{STATUS_LABEL[s]}</Badge>
+            {timeHint && (
+              <span className="text-xs text-text-muted">
+                {s === 'upcoming' ? 'Starts ' : 'Ends '}{timeHint}
+              </span>
+            )}
+          </div>
+        );
+      }
+    },
+    { key: 'participants', header: 'Participants', className: 'w-[13%]', sortable: true, sortAccessor: (r) => r.participants_count ?? 0, render: (r) => <span className="text-sm text-text-muted">{r.participants_count ?? 0}</span> },
+    {
+      key: 'actions', header: '', className: 'w-[24%] text-right', render: (r) => {
+        const status = getContestStatus(r);
+
+        // User is currently in this contest
+        if (joinedContestId === r.id) {
+          return <Link href={`/contests/${r.id}`} className="text-sm font-medium text-brand-primary hover:text-brand-secondary">Continue →</Link>;
+        }
+
+        // Inactive contests — no action
+        if (status === 'inactive') {
+          return <span className="text-sm text-text-muted">Inactive</span>;
+        }
+
+        // User has join history for this contest
+        if (joinedHistory.has(r.id)) {
+          // All past joins were virtual and contest is still virtual → allow rejoin
+          if (status === 'virtual' && virtualContestIds.has(r.id)) {
+            return <Link href={`/contests/${r.id}/view`} className="text-sm font-medium text-brand-primary hover:text-brand-secondary">Rejoin →</Link>;
+          }
+          // Has a regular (non-virtual) join → spectate only
+          return <Link href={`/contests/${r.id}/leaderboard`} className="text-sm font-medium text-text-muted hover:text-foreground">Spectate</Link>;
+        }
+
+        // Default: view the contest info / join page
         return <Link href={`/contests/${r.id}/view`} className="text-sm font-medium text-brand-primary hover:text-brand-secondary">View →</Link>;
       }
     },

--- a/main/src/app/contests/[id]/leaderboard/page.tsx
+++ b/main/src/app/contests/[id]/leaderboard/page.tsx
@@ -57,17 +57,28 @@ export default async function ContestLeaderboardPage({ params }: { params: Promi
   
   let leaderboard: any[] = [];
   if (problemIds.length > 0) {
-    const { data: submissions } = await supabase
-      .from('submissions')
-      .select('user_id, problem_id, results, summary, created_at')
-      .in('problem_id', problemIds);
-      
+    const [submissionsResult, regularParticipantsResult] = await Promise.all([
+      supabase
+        .from('submissions')
+        .select('user_id, problem_id, results, summary, created_at')
+        .in('problem_id', problemIds),
+      supabase
+        .from('join_history')
+        .select('user_id')
+        .eq('contest_id', id)
+        .eq('is_virtual', false)
+    ]);
+
+    const { data: submissions } = submissionsResult;
+    const regularUserIds = new Set((regularParticipantsResult.data || []).map((r: { user_id: string }) => r.user_id));
+
     if (submissions) {
       const problemIdSet = new Set(problemIds);
       const userScores = new Map<string, { totalScore: number; problemScores: Map<string, number>; userId: string }>();
 
       submissions.forEach(submission => {
         if (!problemIdSet.has(submission.problem_id)) return;
+        if (regularUserIds.size > 0 && !regularUserIds.has(submission.user_id)) return;
         const subUserId = submission.user_id;
         if (!userScores.has(subUserId)) {
           userScores.set(subUserId, { totalScore: 0, problemScores: new Map(), userId: subUserId });

--- a/main/src/app/contests/[id]/page.tsx
+++ b/main/src/app/contests/[id]/page.tsx
@@ -57,17 +57,28 @@ export default async function ContestPage({ params }: { params: Promise<{ id: st
   
   let leaderboard: any[] = [];
   if (problemIds.length > 0) {
-    const { data: submissions } = await supabase
-      .from('submissions')
-      .select('user_id, problem_id, results, summary, created_at')
-      .in('problem_id', problemIds);
-      
+    const [submissionsResult, regularParticipantsResult] = await Promise.all([
+      supabase
+        .from('submissions')
+        .select('user_id, problem_id, results, summary, created_at')
+        .in('problem_id', problemIds),
+      supabase
+        .from('join_history')
+        .select('user_id')
+        .eq('contest_id', id)
+        .eq('is_virtual', false)
+    ]);
+
+    const { data: submissions } = submissionsResult;
+    const regularUserIds = new Set((regularParticipantsResult.data || []).map((r: { user_id: string }) => r.user_id));
+
     if (submissions) {
       const problemIdSet = new Set(problemIds);
       const userScores = new Map<string, { totalScore: number; problemScores: Map<string, number>; userId: string }>();
 
       submissions.forEach(submission => {
         if (!problemIdSet.has(submission.problem_id)) return;
+        if (regularUserIds.size > 0 && !regularUserIds.has(submission.user_id)) return;
         const subUserId = submission.user_id;
         if (!userScores.has(subUserId)) {
           userScores.set(subUserId, { totalScore: 0, problemScores: new Map(), userId: subUserId });

--- a/main/src/app/contests/[id]/view/ContestViewClient.tsx
+++ b/main/src/app/contests/[id]/view/ContestViewClient.tsx
@@ -8,7 +8,10 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useCountdown } from '@/contexts/CountdownContext';
 import { LoadingSpinner } from '@/components/AnimationWrapper';
 import { AuthPromptModal } from '@/components/AuthPromptModal';
+import { Badge } from '@/components/ui/Badge';
 import { toast } from '@/components/ui/Toast';
+import { getContestStatus, formatTimeUntil } from '@/utils/contestStatus';
+import type { ContestStatus } from '@/types/contest';
 
 const MarkdownRenderer = dynamic(() => import('@/components/MarkdownRenderer').then(m => m.MarkdownRenderer), { ssr: false });
 
@@ -18,6 +21,9 @@ interface ContestDetail {
   description: string | null;
   length: number;
   created_by: string;
+  starts_at: string | null;
+  ends_at: string | null;
+  is_rated: boolean;
 }
 
 interface ContestViewClientProps {
@@ -25,12 +31,32 @@ interface ContestViewClientProps {
   initialContest?: ContestDetail;
 }
 
+
+const STATUS_VARIANT: Record<ContestStatus, 'success' | 'info' | 'warning' | 'neutral'> = {
+  ongoing:  'success',
+  upcoming: 'info',
+  virtual:  'warning',
+  inactive: 'neutral',
+};
+
+const STATUS_LABEL: Record<ContestStatus, string> = {
+  ongoing:  'Ongoing',
+  upcoming: 'Upcoming',
+  virtual:  'Virtual',
+  inactive: 'Inactive',
+};
+
 export default function ContestViewClient({ error, initialContest }: ContestViewClientProps) {
   const router = useRouter();
   const { user, session, userRole } = useAuth();
   const { startCountdown } = useCountdown();
 
   const isOwnContest = userRole === 'admin' && user?.id === initialContest?.created_by;
+
+  // The view page only loads active contests, so is_active is always true here
+  const status: ContestStatus = initialContest
+    ? getContestStatus({ is_active: true, starts_at: initialContest.starts_at, ends_at: initialContest.ends_at })
+    : 'inactive';
 
   const [joining, setJoining] = useState(false);
   const [showAuthPrompt, setShowAuthPrompt] = useState(false);
@@ -79,7 +105,13 @@ export default function ContestViewClient({ error, initialContest }: ContestView
               Back to Contests
             </Link>
 
-            <h1 className="text-xl font-semibold text-foreground">{initialContest.name}</h1>
+            <div className="flex items-center gap-3 flex-wrap">
+              <h1 className="text-xl font-semibold text-foreground">{initialContest.name}</h1>
+              <Badge variant={STATUS_VARIANT[status]}>{STATUS_LABEL[status]}</Badge>
+              {initialContest.is_rated && (
+                <Badge variant="info">Rated</Badge>
+              )}
+            </div>
 
             <div className="grid md:grid-cols-3 gap-6">
               <div className="md:col-span-2">
@@ -109,6 +141,30 @@ export default function ContestViewClient({ error, initialContest }: ContestView
                         Admins cannot join their own contests.
                       </p>
                     </>
+                  ) : status === 'upcoming' ? (
+                    <>
+                      <div className="w-full h-10 flex items-center justify-center text-sm text-text-muted border border-border rounded-lg bg-surface-2 cursor-not-allowed select-none">
+                        Not yet open
+                      </div>
+                      {initialContest.starts_at && (
+                        <p className="text-xs text-text-muted mt-3 text-center">
+                          Starts {formatTimeUntil(initialContest.starts_at) || 'very soon'}
+                        </p>
+                      )}
+                    </>
+                  ) : status === 'virtual' ? (
+                    <>
+                      <button
+                        onClick={handleJoinClick}
+                        disabled={joining}
+                        className="w-full h-10 bg-brand-primary text-white text-sm font-medium rounded-lg hover:bg-brand-secondary disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                      >
+                        {joining ? <><LoadingSpinner size="sm" /><span>Joining...</span></> : 'Join (Virtual)'}
+                      </button>
+                      <p className="text-xs text-text-muted mt-3 text-center">
+                        Virtual participation. Does not affect the leaderboard.
+                      </p>
+                    </>
                   ) : (
                     <>
                       <button
@@ -118,9 +174,16 @@ export default function ContestViewClient({ error, initialContest }: ContestView
                       >
                         {joining ? <><LoadingSpinner size="sm" /><span>Joining...</span></> : 'Join Contest'}
                       </button>
-                      <p className="text-xs text-text-muted mt-3 text-center">
-                        By joining, you agree to the contest rules.
-                      </p>
+                      {initialContest.ends_at && formatTimeUntil(initialContest.ends_at) && (
+                        <p className="text-xs text-text-muted mt-3 text-center">
+                          Ends {formatTimeUntil(initialContest.ends_at)}
+                        </p>
+                      )}
+                      {(!initialContest.ends_at || !formatTimeUntil(initialContest.ends_at)) && (
+                        <p className="text-xs text-text-muted mt-3 text-center">
+                          By joining, you agree to the contest rules.
+                        </p>
+                      )}
                     </>
                   )}
                 </div>

--- a/main/src/app/manager/contests/create/ManagerCreateContestClient.tsx
+++ b/main/src/app/manager/contests/create/ManagerCreateContestClient.tsx
@@ -11,7 +11,6 @@ import DataTable, { type DataTableColumn } from '@/components/DataTable';
 import { LoadingSpinner } from '@/components/AnimationWrapper';
 
 const MarkdownEditor = dynamic(() => import('@/components/MarkdownEditor').then(m => m.MarkdownEditor), { ssr: false });
-const MarkdownRenderer = dynamic(() => import('@/components/MarkdownRenderer').then(m => m.MarkdownRenderer), { ssr: false });
 
 const inputClass = "w-full h-10 px-3 bg-surface-2 border border-border rounded-md text-sm text-foreground placeholder-text-muted/50 focus:outline-none focus:border-brand-primary focus:ring-2 focus:ring-brand-primary/20";
 
@@ -21,25 +20,46 @@ export default function ManagerCreateContestClient() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
-  const [formData, setFormData] = useState({ name: '', description: '', length: 60 });
+  const [formData, setFormData] = useState({
+    name: '', description: '', length: 60,
+    starts_at: '', ends_at: '', is_rated: false
+  });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: name === 'length' ? parseInt(value) || 0 : value }));
   };
 
+  const handleCheckbox = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData(prev => ({ ...prev, [e.target.name]: e.target.checked }));
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault(); setLoading(true); setError(''); setSuccess('');
+
+    if (formData.starts_at && formData.ends_at && new Date(formData.starts_at) >= new Date(formData.ends_at)) {
+      setError('Start date/time must be before end date/time');
+      setLoading(false);
+      return;
+    }
+
     try {
       const res = await fetch('/api/manager/contests/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}) },
-        body: JSON.stringify(formData)
+        body: JSON.stringify({
+          name: formData.name,
+          description: formData.description,
+          length: formData.length,
+          starts_at: formData.starts_at ? new Date(formData.starts_at).toISOString() : null,
+          ends_at: formData.ends_at ? new Date(formData.ends_at).toISOString() : null,
+          is_rated: formData.is_rated,
+        })
       });
       const json = await res.json();
       if (res.ok) {
         setSuccess('Contest created successfully!');
-        setFormData({ name: '', description: '', length: 60 });
+        setFormData({ name: '', description: '', length: 60, starts_at: '', ends_at: '', is_rated: false });
         setTimeout(() => router.push('/manager/dashboard'), 2000);
       } else { setError(json.error || 'Failed to create contest'); }
     } catch { setError('An unexpected error occurred'); }
@@ -70,6 +90,49 @@ export default function ManagerCreateContestClient() {
               <label htmlFor="length" className="block text-sm font-medium text-foreground">Duration (minutes) *</label>
               <input type="number" id="length" name="length" value={formData.length} onChange={handleChange} required min="1" max="1440" className={inputClass} placeholder="60" />
               <p className="text-xs text-text-muted">Contest duration in minutes (1–1440)</p>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-4 max-w-lg">
+              <div className="space-y-1.5">
+                <label htmlFor="starts_at" className="block text-sm font-medium text-foreground">
+                  Start Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                </label>
+                <input
+                  type="datetime-local"
+                  id="starts_at"
+                  name="starts_at"
+                  value={formData.starts_at}
+                  onChange={handleChange}
+                  className={inputClass}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label htmlFor="ends_at" className="block text-sm font-medium text-foreground">
+                  End Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                </label>
+                <input
+                  type="datetime-local"
+                  id="ends_at"
+                  name="ends_at"
+                  value={formData.ends_at}
+                  onChange={handleChange}
+                  className={inputClass}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              <label className="inline-flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                <input
+                  type="checkbox"
+                  name="is_rated"
+                  className="h-4 w-4 rounded border-border bg-surface-2"
+                  checked={formData.is_rated}
+                  onChange={handleCheckbox}
+                />
+                Rated Contest
+              </label>
+              <p className="text-xs text-text-muted">Rated contests will affect player rankings (not yet implemented).</p>
             </div>
 
             <div>

--- a/main/src/app/manager/contests/manage/ManagerManageContestsClient.tsx
+++ b/main/src/app/manager/contests/manage/ManagerManageContestsClient.tsx
@@ -8,19 +8,33 @@ import { useAuth } from '@/contexts/AuthContext';
 import DataTable, { type DataTableColumn } from '@/components/DataTable';
 import { Badge } from '@/components/ui/Badge';
 import { SkeletonText } from '@/components/LoadingStates';
+import { getContestStatus, toLocalDatetimeInput, fromLocalDatetimeInput } from '@/utils/contestStatus';
+import type { ContestStatus } from '@/types/contest';
 
 interface ContestRow {
   id: string; name: string; length: number | null;
   is_active: boolean | null; created_at: string; updated_at: string;
+  starts_at: string | null; ends_at: string | null; is_rated: boolean;
 }
 
 interface EditState {
-  id: string; name: string; description: string; length: number | null; is_active: boolean;
+  id: string; name: string; description: string; length: number | null;
+  is_active: boolean; starts_at: string; ends_at: string; is_rated: boolean;
 }
 
 const MarkdownEditor = dynamic(() => import('@/components/MarkdownEditor').then(m => m.MarkdownEditor), { ssr: false });
 
 const inputClass = "w-full h-9 px-3 bg-surface-2 border border-border rounded-md text-sm text-foreground focus:outline-none focus:border-brand-primary focus:ring-2 focus:ring-brand-primary/20";
+
+const STATUS_VARIANT: Record<ContestStatus, 'success' | 'info' | 'warning' | 'neutral'> = {
+  ongoing: 'success', upcoming: 'info', virtual: 'warning', inactive: 'neutral',
+};
+const STATUS_LABEL: Record<ContestStatus, string> = {
+  ongoing: 'Ongoing', upcoming: 'Upcoming', virtual: 'Virtual', inactive: 'Inactive',
+};
+const STATUS_SORT_ORDER: Record<ContestStatus, number> = {
+  ongoing: 3, upcoming: 2, virtual: 1, inactive: 0,
+};
 
 export default function ManagerManageContestsClient({ initialContests }: { initialContests: ContestRow[] }) {
   const { session } = useAuth();
@@ -48,7 +62,16 @@ export default function ManagerManageContestsClient({ initialContests }: { initi
       const res = await fetch(`/api/manager/contests/${c.id}`, { headers: token ? { Authorization: `Bearer ${token}` } : undefined });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to load contest');
-      setEditing({ id: c.id, name: data.contest.name, description: data.contest.description || '', length: data.contest.length || null, is_active: !!c.is_active });
+      setEditing({
+        id: c.id,
+        name: data.contest.name,
+        description: data.contest.description || '',
+        length: data.contest.length || null,
+        is_active: !!c.is_active,
+        starts_at: data.contest.starts_at ? toLocalDatetimeInput(data.contest.starts_at) : '',
+        ends_at: data.contest.ends_at ? toLocalDatetimeInput(data.contest.ends_at) : '',
+        is_rated: !!data.contest.is_rated,
+      });
     } catch (e: unknown) { setActionMessage(e instanceof Error ? e.message : 'Failed to open editor'); }
     finally { setFetchingEditContent(false); }
   };
@@ -57,16 +80,37 @@ export default function ManagerManageContestsClient({ initialContests }: { initi
 
   const saveEdit = async () => {
     if (!editing) return;
+    if (editing.starts_at && editing.ends_at && new Date(editing.starts_at) >= new Date(editing.ends_at)) {
+      setActionMessage('Start date/time must be before end date/time');
+      return;
+    }
     try {
       const res = await fetch(`/api/manager/contests/${editing.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
-        body: JSON.stringify({ name: editing.name, description: editing.description, length: editing.length, is_active: editing.is_active }),
+        body: JSON.stringify({
+          name: editing.name,
+          description: editing.description,
+          length: editing.length,
+          is_active: editing.is_active,
+          starts_at: editing.starts_at ? fromLocalDatetimeInput(editing.starts_at) : null,
+          ends_at: editing.ends_at ? fromLocalDatetimeInput(editing.ends_at) : null,
+          is_rated: editing.is_rated,
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Failed to save');
       setActionMessage('Contest updated');
-      setContests(prev => prev.map(c => c.id === editing.id ? { ...c, name: editing.name, is_active: editing.is_active, length: editing.length ?? c.length, updated_at: new Date().toISOString() } : c));
+      setContests(prev => prev.map(c => c.id === editing.id ? {
+        ...c,
+        name: editing.name,
+        is_active: editing.is_active,
+        length: editing.length ?? c.length,
+        starts_at: editing.starts_at ? fromLocalDatetimeInput(editing.starts_at) : null,
+        ends_at: editing.ends_at ? fromLocalDatetimeInput(editing.ends_at) : null,
+        is_rated: editing.is_rated,
+        updated_at: new Date().toISOString(),
+      } : c));
       closeEdit();
     } catch (e: unknown) { setActionMessage(e instanceof Error ? e.message : 'Failed to save'); }
   };
@@ -99,11 +143,18 @@ export default function ManagerManageContestsClient({ initialContests }: { initi
   type Row = ContestRow;
   const columns: Array<DataTableColumn<Row>> = [
     { key: 'name', header: 'Name', className: 'w-[25%]', sortable: true, sortAccessor: (r) => r.name.toLowerCase(), render: (r) => <span className="text-foreground font-medium">{r.name}</span> },
-    { key: 'length', header: 'Length', className: 'w-[15%]', sortable: true, sortAccessor: (r) => r.length ?? 0, render: (r) => <span className="text-text-muted font-mono">{r.length ? `${r.length} min` : '-'}</span> },
-    { key: 'status', header: 'Status', className: 'w-[12%]', sortable: true, sortAccessor: (r) => (r.is_active ? 1 : 0), render: (r) => <Badge variant={r.is_active ? 'success' : 'warning'}>{r.is_active ? 'Active' : 'Inactive'}</Badge> },
+    { key: 'length', header: 'Length', className: 'w-[12%]', sortable: true, sortAccessor: (r) => r.length ?? 0, render: (r) => <span className="text-text-muted font-mono">{r.length ? `${r.length} min` : '-'}</span> },
+    {
+      key: 'status', header: 'Status', className: 'w-[14%]', sortable: true,
+      sortAccessor: (r) => STATUS_SORT_ORDER[getContestStatus({ is_active: !!r.is_active, starts_at: r.starts_at, ends_at: r.ends_at })],
+      render: (r) => {
+        const s = getContestStatus({ is_active: !!r.is_active, starts_at: r.starts_at, ends_at: r.ends_at });
+        return <Badge variant={STATUS_VARIANT[s]}>{STATUS_LABEL[s]}</Badge>;
+      }
+    },
     { key: 'updated', header: 'Updated', className: 'w-[15%]', sortable: true, sortAccessor: (r) => new Date(r.updated_at).getTime(), render: (r) => <span className="text-text-muted text-sm font-mono">{new Date(r.updated_at).toLocaleDateString()}</span> },
     {
-      key: 'actions', header: 'Actions', className: 'w-[33%]', render: (r) => (
+      key: 'actions', header: 'Actions', className: 'w-[34%]', render: (r) => (
         <div className="flex gap-1.5">
           <button onClick={() => openEdit(r)} className="px-2.5 py-1.5 rounded-md text-xs font-medium bg-brand-primary/10 text-brand-primary hover:bg-brand-primary/20">Edit</button>
           <button onClick={() => toggleActive(r)} className="px-2.5 py-1.5 rounded-md text-xs font-medium bg-warning/10 text-warning hover:bg-warning/20">{r.is_active ? 'Deactivate' : 'Activate'}</button>
@@ -177,6 +228,42 @@ export default function ManagerManageContestsClient({ initialContests }: { initi
                         <label className="block text-sm font-medium text-foreground">Length (minutes)</label>
                         <input type="number" className={`${inputClass} max-w-xs`} value={editing.length ?? ''} onChange={e => setEditing(s => s ? { ...s, length: e.target.value ? Number(e.target.value) : null } : s)} />
                         <p className="text-xs text-text-muted">Leave blank for unspecified length.</p>
+                      </div>
+                      <div className="grid md:grid-cols-2 gap-4">
+                        <div className="space-y-1.5">
+                          <label className="block text-sm font-medium text-foreground">
+                            Start Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                          </label>
+                          <input
+                            type="datetime-local"
+                            className={inputClass}
+                            value={editing.starts_at}
+                            onChange={e => setEditing(s => s ? { ...s, starts_at: e.target.value } : s)}
+                          />
+                        </div>
+                        <div className="space-y-1.5">
+                          <label className="block text-sm font-medium text-foreground">
+                            End Date/Time <span className="text-text-muted font-normal text-xs">(optional)</span>
+                          </label>
+                          <input
+                            type="datetime-local"
+                            className={inputClass}
+                            value={editing.ends_at}
+                            onChange={e => setEditing(s => s ? { ...s, ends_at: e.target.value } : s)}
+                          />
+                        </div>
+                      </div>
+                      <div>
+                        <label className="inline-flex items-center gap-2 text-sm text-foreground cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="h-4 w-4 rounded border-border bg-surface-2"
+                            checked={editing.is_rated}
+                            onChange={e => setEditing(s => s ? { ...s, is_rated: e.target.checked } : s)}
+                          />
+                          Rated Contest
+                        </label>
+                        <p className="text-xs text-text-muted mt-1">Rated contests will affect player rankings (not yet implemented).</p>
                       </div>
                       <div className="space-y-1.5">
                         <label className="block text-sm font-medium text-foreground">Description (Markdown)</label>

--- a/main/src/app/manager/contests/manage/page.tsx
+++ b/main/src/app/manager/contests/manage/page.tsx
@@ -19,7 +19,7 @@ export default async function ManagerManageContestsPage() {
 
   const { data } = await supabase
     .from('contests')
-    .select('id,name,length,is_active,updated_at,created_at');
+    .select('id,name,length,is_active,updated_at,created_at,starts_at,ends_at,is_rated');
 
   return <ManagerManageContestsClient initialContests={data || []} />;
 }

--- a/main/src/types/contest.ts
+++ b/main/src/types/contest.ts
@@ -1,3 +1,5 @@
+export type ContestStatus = 'upcoming' | 'ongoing' | 'virtual' | 'inactive';
+
 export interface Contest {
   id: string;
   name: string;
@@ -5,10 +7,11 @@ export interface Contest {
   length: number;
   created_at: string | null;
   updated_at: string | null;
-  is_active: boolean; // reflects current activation status
+  is_active: boolean;
+  starts_at: string | null;
+  ends_at: string | null;
+  is_rated: boolean;
   // Added at runtime (not necessarily persisted columns) for listing enrichment
   participants_count?: number;
   problems_count?: number;
 }
-
-

--- a/main/src/utils/contestStatus.ts
+++ b/main/src/utils/contestStatus.ts
@@ -1,0 +1,69 @@
+import type { ContestStatus } from '@/types/contest';
+
+/**
+ * Converts a UTC ISO timestamp string to a value suitable for a datetime-local input.
+ * datetime-local inputs expect local time (YYYY-MM-DDTHH:MM), not UTC.
+ */
+export function toLocalDatetimeInput(isoString: string): string {
+  const d = new Date(isoString);
+  const offsetMs = d.getTimezoneOffset() * 60_000;
+  return new Date(d.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+/**
+ * Converts a datetime-local input value (local time, no timezone) to a UTC ISO string.
+ * Browsers parse YYYY-MM-DDTHH:MM as local time, so new Date(...).toISOString() gives UTC.
+ */
+export function fromLocalDatetimeInput(localValue: string): string {
+  return new Date(localValue).toISOString();
+}
+
+/**
+ * Returns a human-readable "in X days/hours/minutes" string for a future timestamp.
+ * If the timestamp is in the past, returns an empty string.
+ */
+export function formatTimeUntil(isoString: string): string {
+  const ms = new Date(isoString).getTime() - Date.now();
+  if (ms <= 0) return '';
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 60) return `in ${minutes} min`;
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `in ${days} day${days !== 1 ? 's' : ''}`;
+}
+
+interface ContestStatusInput {
+  is_active: boolean;
+  starts_at: string | null;
+  ends_at: string | null;
+}
+
+/**
+ * Computes the current display status of a contest purely from its data.
+ * Never stored in the database — always computed at call time.
+ *
+ * - inactive:  is_active = false
+ * - upcoming:  is_active = true, now < starts_at
+ * - ongoing:   is_active = true, starts_at <= now <= ends_at
+ * - virtual:   is_active = true, now > ends_at  (or no time window set)
+ */
+export function getContestStatus(contest: ContestStatusInput): ContestStatus {
+  if (!contest.is_active) return 'inactive';
+
+  const now = Date.now();
+  const startsAt = contest.starts_at ? new Date(contest.starts_at).getTime() : null;
+  const endsAt = contest.ends_at ? new Date(contest.ends_at).getTime() : null;
+
+  // No time window set — treat as virtual (backward compat for old contests)
+  if (startsAt === null && endsAt === null) return 'virtual';
+
+  if (startsAt !== null && now < startsAt) return 'upcoming';
+
+  if (startsAt !== null && endsAt !== null && now >= startsAt && now <= endsAt) {
+    return 'ongoing';
+  }
+
+  // is_active=true but ends_at is in the past (or only starts_at is set with no end)
+  return 'virtual';
+}


### PR DESCRIPTION
- DB: add starts_at / ends_at / is_rated to contests; is_virtual to join_history
- Introduce four computed statuses: Upcoming / Ongoing / Virtual / Inactive via shared getContestStatus() utility (never stored in DB)
- Virtual contests allow free re-join without affecting the leaderboard; leaderboard filters out is_virtual participants across all three query paths
- Join API enforces status rules: blocks upcoming, allows virtual re-join, stamps is_virtual on every join_history record
- Manager + admin create/edit forms: start/end datetime pickers, rated checkbox, proper UTC timezone conversion for datetime-local inputs
- User-facing contests listing: 4-state status badges with inline time hints (Starts in 3 days / Ends in 2h) under each badge
- Contest view page: status badge, rated badge, upcoming/ongoing/virtual contextual join panel with time-remaining display
- Fix RLS infinite recursion on contests UPDATE policy (self-referential is_active subquery replaced with simple admin ownership check)
- Update ER diagram and sequence diagram docs